### PR TITLE
Add Vysmo Text to Text section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ This list contains the most useful tools and data for creating web animations.
 - [Shuffle-text](https://github.com/ics-ikeda/shuffle-text) - Shuffle-text is JavaScript text effect library such as cool legacy of Flash.
 - [Typebot](https://github.com/akzhy/typebot) - JavaScript library for typing animation.
 - [Blotter](https://github.com/bradley/Blotter) - A JavaScript API for drawing unconventional text effects on the web.
+- [Vysmo Text](https://github.com/vysmodev/vysmo) - Tiny text animation library with 243 presets (enter/exit/emphasis), grapheme-safe splitting via Intl.Segmenter, and scroll scrubbing. Tree-shakable, ~3 KB gzipped.
 
 ## React
 


### PR DESCRIPTION
Adds Vysmo Text to the Text section.

- **What it is**: A new text animation library with 243 presets across enter/exit/emphasis categories. Open source, MIT licensed, zero dependencies.
- **Why it fits**: Existing entries in this section are typewriter-style (Malarkey, Typed.js, Typebot) or single-effect (Shuffle-text, Blotter). Vysmo Text is a general-purpose choreography library — closer in scope to what's offered in the Common section, but text-specific.
- **Differentiators**: Grapheme-safe splitting via Intl.Segmenter (handles emoji clusters, RTL scripts, and combining marks), single master-clock architecture supporting scroll scrubbing via handle.seek(progress), tree-shakable presets, ~3 KB gzipped.
- **Repo**: https://github.com/vysmodev/vysmo
- **Homepage & live catalog**: https://vysmo.com/text